### PR TITLE
feat: add validate check for batch auction with maxBidAmount

### DIFF
--- a/x/fundraising/keeper/keeper_test.go
+++ b/x/fundraising/keeper/keeper_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"encoding/binary"
+	"strings"
 	"testing"
 	"time"
 
@@ -256,6 +257,7 @@ func exchangedSellingAmount(price sdk.Dec, coin sdk.Coin) sdk.Int {
 
 // parseCoin parses and returns sdk.Coin.
 func parseCoin(s string) sdk.Coin {
+	s = strings.ReplaceAll(s, "_", "")
 	coin, err := sdk.ParseCoinNormalized(s)
 	if err != nil {
 		panic(err)
@@ -265,6 +267,7 @@ func parseCoin(s string) sdk.Coin {
 
 // parseCoins parses and returns sdk.Coins.
 func parseCoins(s string) sdk.Coins {
+	s = strings.ReplaceAll(s, "_", "")
 	coins, err := sdk.ParseCoinsNormalized(s)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR is to add the functionality to check if bid amount is larger than `maxBidAmount` for batch auction.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #116 

## Tasks

- [x] Add the functionality to check if bid amount is larger than `maxBidAmount` for batch auction in `keeper/bid.go`
- [x] Add test cases to check if bid amount is larger than `maxBidAmount` for batch auction in `keeper/bid_test.go`

## References

- 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
